### PR TITLE
Merge SKOS features and upstream

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         ruby-version: ['2.7', '3.0']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ontologies_api_client (2.0.3)
-      activesupport (= 6.0.4.1)
+      activesupport (= 6.1.5.1)
       excon
       faraday
       faraday-excon (~> 2.0.0)
@@ -15,32 +15,32 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.4.1)
+    activesupport (6.1.5.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     coderay (1.1.3)
-    concurrent-ruby (1.1.9)
-    excon (0.91.0)
+    concurrent-ruby (1.1.10)
+    excon (0.95.0)
     faraday (2.0.1)
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
     faraday-excon (2.0.0)
       excon (>= 0.27.4)
       faraday (~> 2.0.0.alpha.pre.2)
-    faraday-multipart (1.0.3)
-      multipart-post (>= 1.2, < 3)
-    faraday-net_http (2.0.1)
-    i18n (1.10.0)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
+    faraday-net_http (2.1.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     lz4-ruby (0.3.3)
     method_source (1.0.0)
-    minitest (5.15.0)
+    minitest (5.16.3)
     multi_json (1.15.0)
-    multipart-post (2.1.1)
-    oj (3.13.11)
+    multipart-post (2.2.3)
+    oj (3.13.23)
     power_assert (2.0.1)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -50,10 +50,9 @@ GEM
     spawnling (2.1.5)
     test-unit (3.5.3)
       power_assert
-    thread_safe (0.3.6)
-    tzinfo (1.2.10)
-      thread_safe (~> 0.1)
-    zeitwerk (2.5.4)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ontologies_api_client (2.0.3)
+    ontologies_api_client (2.2.0)
       activesupport (= 6.1.5.1)
       excon
       faraday
@@ -67,4 +67,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.1.4
+   2.3.22

--- a/lib/ontologies_api_client/models/class.rb
+++ b/lib/ontologies_api_client/models/class.rb
@@ -6,11 +6,9 @@ module LinkedData
     module Models
       class Class < LinkedData::Client::Base
         HTTP = LinkedData::Client::HTTP
-        @media_type = "http://www.w3.org/2002/07/owl#Class"
-        @include_attrs = "prefLabel,definition,synonym,obsolete,hasChildren"
+        @include_attrs = "prefLabel,definition,synonym,obsolete,hasChildren,inScheme,memberOf"
         @include_attrs_full = "prefLabel,definition,synonym,obsolete,properties,hasChildren,children"
         @attrs_always_present = :prefLabel, :definition, :synonym, :obsolete, :properties, :hasChildren, :children
-
         alias :fullId :id
 
         # triple store predicate is <http://www.w3.org/2002/07/owl#deprecated>

--- a/lib/ontologies_api_client/models/collection.rb
+++ b/lib/ontologies_api_client/models/collection.rb
@@ -1,0 +1,12 @@
+require_relative "../base"
+
+module LinkedData
+  module Client
+    module Models
+      class Collection < LinkedData::Client::Base
+        include LinkedData::Client::Collection
+        @media_type =  "http://www.w3.org/2004/02/skos/core#Collection"
+      end
+    end
+  end
+end

--- a/lib/ontologies_api_client/models/scheme.rb
+++ b/lib/ontologies_api_client/models/scheme.rb
@@ -1,0 +1,12 @@
+require_relative "../base"
+
+module LinkedData
+  module Client
+    module Models
+      class Scheme < LinkedData::Client::Base
+        include LinkedData::Client::Collection
+        @media_type = "http://www.w3.org/2004/02/skos/core#ConceptScheme"
+      end
+    end
+  end
+end

--- a/lib/ontologies_api_client/models/skos_xl_label.rb
+++ b/lib/ontologies_api_client/models/skos_xl_label.rb
@@ -1,0 +1,12 @@
+require_relative "../base"
+
+module LinkedData
+  module Client
+    module Models
+      class Label < LinkedData::Client::Base
+        include LinkedData::Client::Collection
+        @media_type = "http://www.w3.org/2008/05/skos-xl#Label"
+      end
+    end
+  end
+end

--- a/ontologies_api_client.gemspec
+++ b/ontologies_api_client.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "ontologies_api_client"
   gem.require_paths = ["lib"]
-  gem.version       = "2.0.3"
+  gem.version       = "2.2.0"
 
   gem.add_dependency('activesupport', '6.1.5.1')
   gem.add_dependency('excon')

--- a/ontologies_api_client.gemspec
+++ b/ontologies_api_client.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = "2.0.3"
 
-  gem.add_dependency('activesupport', '6.0.4.1')
+  gem.add_dependency('activesupport', '6.1.5.1')
   gem.add_dependency('excon')
   gem.add_dependency('faraday')
   gem.add_dependency('faraday-excon', '~> 2.0.0')


### PR DESCRIPTION
### Changes

- Add SKOS models (scheme, collection, and skos_xl label) (https://github.com/ontoportal-lirmm/ontologies_api_ruby_client/pull/7/commits/839018c0fa7c93ac8c8bea4e013c2fa03d91c4ef)
- Add `inScheme` and `memberOf` attributes to class/concept model (https://github.com/ontoportal-lirmm/ontologies_api_ruby_client/pull/7/commits/4bcfad5b8ed346d84f4a82011e2b76fa711317f4)
- Add link explorer by Id (https://github.com/ontoportal-lirmm/ontologies_api_ruby_client/pull/7/commits/9a93fbb4f1e9e9aa859297a522baa7462c542a0e)
- Add the possibility for a model to have multiple media types (e.g class model will both owl:Class and skos:Concept) (https://github.com/ontoportal-lirmm/ontologies_api_ruby_client/pull/7/commits/9a93fbb4f1e9e9aa859297a522baa7462c542a0e)
- Merge branch tp upstream v2.2.0 (https://github.com/ontoportal-lirmm/ontologies_api_ruby_client/pull/7/commits/f26f4f48c38f80757d852010cf9682b6cdc1c330)

### Related branches

- [pr/feautre/add-multiple-media-types-models](https://github.com/ontoportal-lirmm/ontologies_api_ruby_client/tree/pr/feautre/add-multiple-media-types-models) => https://github.com/ncbo/ontologies_api_ruby_client/pull/17
- [pr/feature/add-link-explorer-by-id](https://github.com/ontoportal-lirmm/ontologies_api_ruby_client/tree/pr/feature/add-link-explorer-by-id) => https://github.com/ncbo/ontologies_api_ruby_client/pull/15
- [feature/add-skos-models](https://github.com/ontoportal-lirmm/ontologies_api_ruby_client/tree/feature/add-skos-models)