### PR TITLE
Fix: optimize the way we do our calls to the API 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -63,4 +64,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.3.23
+   2.4.21

--- a/lib/ontologies_api_client/collection.rb
+++ b/lib/ontologies_api_client/collection.rb
@@ -75,16 +75,16 @@ module LinkedData
 
         ##
         # Find a resource by id
+        # @deprecated replace with "get"
         def find(id, params = {})
-          found = where do |obj|
-            obj.id.eql?(id)
-          end
-          found.first
+          [get(id, params)]
         end
 
         ##
         # Get a resource by id (this will retrieve it from the REST service)
         def get(id, params = {})
+          path = collection_path
+          id = "#{path}/#{id}" unless id.include?(path)
           HTTP.get(id, params)
         end
 

--- a/lib/ontologies_api_client/collection.rb
+++ b/lib/ontologies_api_client/collection.rb
@@ -25,7 +25,7 @@ module LinkedData
         ##
         # Get all top-level links for the API
         def top_level_links
-          HTTP.get(LinkedData::Client.settings.rest_url)
+          @top_level_links||= HTTP.get(LinkedData::Client.settings.rest_url)
         end
 
         ##

--- a/lib/ontologies_api_client/http.rb
+++ b/lib/ontologies_api_client/http.rb
@@ -61,7 +61,7 @@ module LinkedData
         invalidate_cache = params.delete(:invalidate_cache) || false
 
         begin
-          puts "Getting: #{path} with #{params}" if $DEBUG
+          puts "Getting: #{path} with #{params}" if $DEBUG_API_CLIENT
           begin
             response = conn.get do |req|
               req.url path
@@ -87,7 +87,7 @@ module LinkedData
             obj = recursive_struct(load_json(response.body))
           end
         rescue StandardError => e
-          puts "Problem getting #{path}" if $DEBUG
+          puts "Problem getting #{path}" if $DEBUG_API_CLIENT
           raise e
         end
         obj
@@ -143,7 +143,7 @@ module LinkedData
       end
 
       def self.delete(id)
-        puts "Deleting #{id}" if $DEBUG
+        puts "Deleting #{id}" if $DEBUG_API_CLIENT
         response = conn.delete id
         raise StandardError, response.body if response.status >= 500
 

--- a/lib/ontologies_api_client/http.rb
+++ b/lib/ontologies_api_client/http.rb
@@ -2,7 +2,7 @@ require 'oj'
 require 'multi_json'
 require 'digest'
 require 'ostruct'
-
+require 'benchmark'
 ##
 # This monkeypatch makes OpenStruct act like Struct objects
 class OpenStruct
@@ -58,18 +58,20 @@ module LinkedData
         raw = options[:raw] || false # return the unparsed body of the request
         params = params.delete_if { |k, v| v == nil || v.to_s.empty? }
         params[:ncbo_cache_buster] = Time.now.to_f if raw # raw requests don't get cached to ensure body is available
-        invalidate_cache = params.delete(:invalidate_cache) || false
-
+        invalidate_cache = params.delete(:invalidate_cache) || $API_CLIENT_INVALIDATE_CACHE || false
         begin
-          puts "Getting: #{path} with #{params}" if $DEBUG_API_CLIENT
           begin
-            response = conn.get do |req|
-              req.url path
-              req.params = params.dup
-              req.options[:timeout] = 60
-              req.headers.merge(headers)
-              req.headers[:invalidate_cache] = invalidate_cache
+            response = nil
+            time = Benchmark.realtime do
+              response = conn.get do |req|
+                req.url path
+                req.params = params.dup
+                req.options[:timeout] = 60
+                req.headers.merge(headers)
+                req.headers[:invalidate_cache] = invalidate_cache
+              end
             end
+            puts "Getting: #{path} with #{params} (#{time}s)" if $DEBUG_API_CLIENT
           rescue Exception => e
             params = Faraday::Utils.build_query(params)
             path << "?" unless params.empty? || path.include?("?")

--- a/lib/ontologies_api_client/models/ontology.rb
+++ b/lib/ontologies_api_client/models/ontology.rb
@@ -108,7 +108,7 @@ module LinkedData
         # Override to search for views as well by default
         # Views get hidden on the REST service unless the `include_views`
         # parameter is set to `true`
-        def find(id, params = {})
+        def self.find(id, params = {})
           params[:include_views] = params[:include_views] || true
           super(id, params)
         end
@@ -119,6 +119,9 @@ module LinkedData
           "acronym,administeredBy,group,hasDomain,name,notes,projects,reviews,summaryOnly,viewingRestriction"
         end
 
+        def self.find_by_acronym(acronym, params = {})
+          [find(acronym, params)]
+        end
       end
     end
   end

--- a/lib/ontologies_api_client/models/ontology.rb
+++ b/lib/ontologies_api_client/models/ontology.rb
@@ -52,10 +52,6 @@ module LinkedData
           return administeredBy.any? {|u| u == user.id}
         end
 
-        def invalidate_cache(cache_refresh_all = true)
-          self.class.all(invalidate_cache: true, include_views: true)
-          super(cache_refresh_all)
-        end
 
         # ACL with administrators
         def full_acl

--- a/lib/ontologies_api_client/read_write.rb
+++ b/lib/ontologies_api_client/read_write.rb
@@ -90,7 +90,7 @@ module LinkedData
         HTTP.get(self.id, invalidate_cache: true) if self.id
         session = Thread.current[:session]
         session[:last_updated] = Time.now.to_f if session
-        refresh_cache
+        # refresh_cache
       end
 
       def refresh_cache


### PR DESCRIPTION
### Context 
This repository is responsible for translating our front Ruby code to the corresponding HTTP call to the API, e.g `Ontology.all` we will be translated to `/ontologies` and `Ontology.get(id)` to `/ontologies/{id}`

### Issue 
Some important optimization can be easily done, below is a list of the issues that this PR is resolving: 
* Fetching top-level links on each request 
For any request done to the API we do at list 2, e.g `Ontology.all` 
```ruby
Getting: https://data.agroportal.lirmm.fr 
Getting: https://data.agroportal.lirmm.fr/ontologies 
```
Instead of just `https://data.agroportal.lirmm.fr/ontologies`,   we do the first call to get the `links` part of `https://data.agroportal.lirmm.fr ` and to know the endpoint of the resource, for example for `Ontology` it would be `https://data.agroportal.lirmm.fr/ontologies`.
The fix here was to save the response returned by `https://data.agroportal.lirmm.fr` the first in a variable so that we do call each time. 

In the future, we can remove this call. 

* Using `.find()` instead systematicity `.get()`
This one is the one really demanding in response time, which when we do `Ontology.find(id)` to go to `/ontologies/{id}` and return the JSON-LD of an ontology. In reality, was doing `/ontologies`, fetching all ontologies, and then filtering the result by the `id`  provided.

The fix here is to deprecate  `.find()` method (and remove it in the future), and replace it with `.get()` which does the direct call  `Ontology.find(id) => https://data.agroportal.lirmm.fr/ontologies/{id}` 

* Refresh caching on each update 

Each time we do a save or an update we refresh the cache,  of the current resource updated/saved, all its brothers and all the ontologies, and all the submissions and all the users.

So for example if update/save an `Ontology  1`, I refresh its cache (which is good), but also all the ontologies, and all the ontologies a second time, and all the submissions and all the users caches. Resulting in these calls on each update/save 

```ruby 
Getting: https://data.agroportal.lirmm.fr/ontologies/WHEATPHENOTYPE (0.2069408730021678s)
Update (Put): https://data.agroportal.lirmm.fr/ontologies/WHEATPHENOTYPE

Getting: https://data.agroportal.lirmm.fr/ontologies/WHEATPHENOTYPE with invalidate cache header (0.2069408730021678s)
Getting: https://data.agroportal.lirmm.fr/ontologies with invalidate cache header  (1.135303320013918s)
Getting: https://data.agroportal.lirmm.fr/submissions with invalidate cache header   (1.0787174180150032s)
Getting: https://data.agroportal.lirmm.fr/users  with invalidate cache header (0.3540415579918772s)
```
### Changes
* use $DEBUG_API_CLIENT instead of $DEBUG for debugging request (https://github.com/ontoportal-lirmm/ontologies_api_ruby_client/pull/14/commits/169afb7c1002f9db2b3276af36d552575cc80ba2)
* add $API_CLIENT_INVALIDATE_CACHE option to disable cache (https://github.com/ontoportal-lirmm/ontologies_api_ruby_client/pull/14/commits/38e4299d8cad25aef71779704d9eff1aabbca1ce)
* save and re-use the top_level_links http response as the result do not change (https://github.com/ontoportal-lirmm/ontologies_api_ruby_client/pull/14/commits/fe41668785affb77cc6d8a133da800819529447f) 
* deprecate the find method in favor of get method for better performance (https://github.com/ontoportal-lirmm/ontologies_api_ruby_client/pull/14/commits/ab9048ec0dd2b4b5ef1aef9d40fa0df61282b5ef)
* disable the refresh_cache on each update call (https://github.com/ontoportal-lirmm/ontologies_api_ruby_client/pull/14/commits/cb62d5cb6ff91310ca2f4310e6b50758a22578cd)
