### PR TITLE
Fix: Return search results as an object instead of a hash

### DIFF
--- a/config/config.test.rb
+++ b/config/config.test.rb
@@ -25,7 +25,7 @@ LinkedData::Client.config do |config|
     #   color: '#1e2251',
     # },
     biodivportal: {
-      api: 'https://data.biodivportal.gfbio.org/',
+      api: 'https://data.biodivportal.gfbio.dev/',
       apikey: "47a57aa3-7b54-4f34-b695-dbb5f5b7363e",
       color: '#1e2251',
     }

--- a/lib/ontologies_api_client/models/class.rb
+++ b/lib/ontologies_api_client/models/class.rb
@@ -83,7 +83,7 @@ module LinkedData
               merged_collections[:errors] << result.errors
             end
           end
-          merged_collections
+          OpenStruct.new(merged_collections)
 
         end
 

--- a/test/models/test_federation.rb
+++ b/test/models/test_federation.rb
@@ -124,14 +124,14 @@ class FederationTest < LinkedData::Client::TestCase
     query = 'test'
 
     time1 = Benchmark.realtime do
-      @search_results = LinkedData::Client::Models::Class.search(query)[:collection]
+      @search_results = LinkedData::Client::Models::Class.search(query).collection
     end
 
     time2 = Benchmark.realtime do
-      @federated_search_results = LinkedData::Client::Models::Class.search(query, {federate: 'true'})[:collection]
+      @federated_search_results = LinkedData::Client::Models::Class.search(query, {federate: 'true'}).collection
     end
 
-    puts "Search results: #{@search_results .length} in #{time1}s"
+    puts "Search results: #{@search_results.length} in #{time1}s"
     puts "Federated search results: #{@federated_search_results.length} in #{time2}s"
 
     refute_equal @search_results.length, @federated_search_results.length


### PR DESCRIPTION
### PR Description
Return search results as an object instead of a hash to keep backward compatible after adding federation.