### PR TITLE
Fix: Saving errors status in cache

### DIFF
--- a/lib/ontologies_api_client/http.rb
+++ b/lib/ontologies_api_client/http.rb
@@ -77,7 +77,7 @@ module LinkedData
                 req.headers[:invalidate_cache] = invalidate_cache
               end
             end
-            puts "Getting: #{path} with #{params} (t: #{time}s - cache: #{response.headers["X-Rack-Cache"]})" if $DEBUG_API_CLIENT
+            log "Getting: #{path} with #{params} (t: #{time}s - cache: #{response.headers["X-Rack-Cache"]})" if $DEBUG_API_CLIENT
           rescue Exception => e
             params = Faraday::Utils.build_query(params)
             path << "?" unless params.empty? || path.include?("?")
@@ -95,7 +95,7 @@ module LinkedData
             obj = recursive_struct(load_json(response.body))
           end
         rescue StandardError => e
-          puts "Problem getting #{path}" if $DEBUG_API_CLIENT
+          log "Problem getting #{path}"
           raise e
         end
         obj
@@ -151,7 +151,7 @@ module LinkedData
       end
 
       def self.delete(id)
-        puts "Deleting #{id}" if $DEBUG_API_CLIENT
+        log "Deleting #{id}" if $DEBUG_API_CLIENT
         response = conn.delete id
         raise StandardError, response.body if response.status >= 500
 
@@ -162,6 +162,9 @@ module LinkedData
         recursive_struct(load_json(json))
       end
 
+      def self.log(message)
+        puts message if $DEBUG_API_CLIENT
+      end
       private
 
       def self.custom_req(obj, file, file_attribute, req)

--- a/lib/ontologies_api_client/request_federation.rb
+++ b/lib/ontologies_api_client/request_federation.rb
@@ -22,6 +22,7 @@ module LinkedData
             end
 
             unless portal_status
+              HTTP.log("Error in federation #{portal_name} is down status cached for 10 minutes")
               next [OpenStruct.new(errors: "Problem retrieving #{portal_name}")]
             end
 
@@ -30,7 +31,7 @@ module LinkedData
               portal_params = params[portal_name.to_s.downcase] || params
               HTTP.get(link.call(conn.url_prefix.to_s.chomp('/')), portal_params, connection: conn)
             rescue Exception => e
-              Rails.cache.write("federation_portal_up_#{portal_name}", false, expires_in: 10.minutes)
+              HTTP.log("Error in federation #{portal_name} is down status cached for 10 minutes")
               [OpenStruct.new(errors: "Problem retrieving #{link.call(conn.url_prefix.to_s.chomp('/')) || conn.url_prefix}")]
             end
           end

--- a/lib/ontologies_api_client/request_federation.rb
+++ b/lib/ontologies_api_client/request_federation.rb
@@ -32,6 +32,7 @@ module LinkedData
               HTTP.get(link.call(conn.url_prefix.to_s.chomp('/')), portal_params, connection: conn)
             rescue Exception => e
               HTTP.log("Error in federation #{portal_name} is down status cached for 10 minutes")
+              Rails.cache.write("federation_portal_up_#{portal_name}", false, expires_in: 10.minutes) unless internal_call?(conn)
               [OpenStruct.new(errors: "Problem retrieving #{link.call(conn.url_prefix.to_s.chomp('/')) || conn.url_prefix}")]
             end
           end
@@ -61,6 +62,9 @@ module LinkedData
           portals
         end
 
+        def internal_call?(conn)
+          conn.url_prefix.to_s.start_with?(LinkedData::Client::HTTP.conn.url_prefix.to_s)
+        end
 
         def portal_name_from_id(id)
           LinkedData::Client::HTTP.federated_conn.find { |_, value| value.url_prefix.to_s.eql?(id) }&.first || ''


### PR DESCRIPTION
Fixes agroportal/project-management#712. In the scope of the federation work (#24), we introduced a status cache to store the availability of federated portals. If a portal is down, its status is cached for 10 minutes to avoid unnecessary requests. However, the issue was that errors from the current portal were also cached, unintentionally blocking it for 10 minutes and requiring to clear the cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved debug logging with a centralized method, making it easier to control and standardize debug output.
  - Enhanced error logging for portal connectivity issues, providing clearer information when a portal is down.

- **Refactor**
  - Streamlined how portal parameters are handled and improved detection of internal calls for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->